### PR TITLE
Forecast Endpoint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,8 @@ gem 'jbuilder', '~> 2.5'
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.1.0', require: false
 
+gem 'fast_jsonapi'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
@@ -46,7 +48,7 @@ group :development, :test do
   gem 'simplecov'
   gem 'shoulda-matchers'
   gem 'activesupport'
-  
+
 end
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -48,7 +48,6 @@ group :development, :test do
   gem 'simplecov'
   gem 'shoulda-matchers'
   gem 'activesupport'
-
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,6 +77,8 @@ GEM
     factory_bot_rails (5.0.2)
       factory_bot (~> 5.0.2)
       railties (>= 4.2.0)
+    fast_jsonapi (1.5)
+      activesupport (>= 4.2)
     ffi (1.11.1)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
@@ -222,6 +224,7 @@ DEPENDENCIES
   capybara
   coffee-rails (~> 4.2)
   factory_bot_rails
+  fast_jsonapi
   jbuilder (~> 2.5)
   launchy
   listen (>= 3.0.5, < 3.2)

--- a/app/controllers/api/v1/forecast_controller.rb
+++ b/app/controllers/api/v1/forecast_controller.rb
@@ -1,0 +1,5 @@
+class Api::V1::ForecastController < ApplicationController
+  def show
+    render json: ForecastSerializer.new
+  end
+end

--- a/app/controllers/api/v1/forecast_controller.rb
+++ b/app/controllers/api/v1/forecast_controller.rb
@@ -1,5 +1,12 @@
-class Api::V1::ForecastController < ApplicationController
-  def show
-    render json: ForecastSerializer.new
+# frozen_string_literal: true
+
+module Api
+  module V1
+    # A controller to take in a forecast request, process it, and return JSON
+    class ForecastController < ApplicationController
+      def show
+        render json: ForecastSerializer.new
+      end
+    end
   end
 end

--- a/app/serializers/forecast_serializer.rb
+++ b/app/serializers/forecast_serializer.rb
@@ -1,4 +1,6 @@
+# frozen_string_literal: true
+
+# A serializer for processing a Forecast object into a JSON response
 class ForecastSerializer
   include FastJsonapi::ObjectSerializer
-
 end

--- a/app/serializers/forecast_serializer.rb
+++ b/app/serializers/forecast_serializer.rb
@@ -1,0 +1,4 @@
+class ForecastSerializer
+  include FastJsonapi::ObjectSerializer
+
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,7 @@
 Rails.application.routes.draw do
-  # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+  namespace :api do
+    namespace :v1 do
+      get '/forecast', to: 'forecast#show'
+    end
+  end
 end

--- a/spec/requests/forecast_spec.rb
+++ b/spec/requests/forecast_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+describe 'Forecast API' do
+  before :each do
+
+  end
+
+  it 'sends the weather for Denver' do
+    get '/api/v1/forecast?location=denver, co'
+
+    expect(response).to be_successful
+
+    forecast = JSON.parse(response.body)
+
+    expect(forecast['currently']['temperature']).to eq('86')
+  end
+end

--- a/spec/requests/forecast_spec.rb
+++ b/spec/requests/forecast_spec.rb
@@ -1,8 +1,9 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 describe 'Forecast API' do
   before :each do
-
   end
 
   it 'sends the weather for Denver' do


### PR DESCRIPTION
This is a very rough PR. Functionality is not fully baked, but it's about as far as I can get without implementing the Services.
- Brings in FastJSON API gem
- Initial spec for Forecast Endpoint
- Initial /forecast route
- Initial ForecastController with #show action
- Initial ForecastSerializer with no info

Should have started with the Services, but this also felt like a good point to begin from. 