### PR TITLE
GoogleMaps Service and Geocode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key
+
+# Ignore application configuration
+/config/application.yml

--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,7 @@ gem 'jbuilder', '~> 2.5'
 gem 'bootsnap', '>= 1.1.0', require: false
 
 gem 'fast_jsonapi'
+gem 'figaro'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,7 @@ gem 'jbuilder', '~> 2.5'
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.1.0', require: false
 
+gem 'faraday'
 gem 'fast_jsonapi'
 gem 'figaro'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,6 +77,8 @@ GEM
     factory_bot_rails (5.0.2)
       factory_bot (~> 5.0.2)
       railties (>= 4.2.0)
+    faraday (0.15.4)
+      multipart-post (>= 1.2, < 3)
     fast_jsonapi (1.5)
       activesupport (>= 4.2)
     ffi (1.11.1)
@@ -108,6 +110,7 @@ GEM
     mini_portile2 (2.4.0)
     minitest (5.11.3)
     msgpack (1.3.0)
+    multipart-post (2.1.1)
     nio4r (2.4.0)
     nokogiri (1.10.3)
       mini_portile2 (~> 2.4.0)
@@ -226,6 +229,7 @@ DEPENDENCIES
   capybara
   coffee-rails (~> 4.2)
   factory_bot_rails
+  faraday
   fast_jsonapi
   figaro
   jbuilder (~> 2.5)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,6 +80,8 @@ GEM
     fast_jsonapi (1.5)
       activesupport (>= 4.2)
     ffi (1.11.1)
+    figaro (1.1.1)
+      thor (~> 0.14)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     i18n (1.6.0)
@@ -225,6 +227,7 @@ DEPENDENCIES
   coffee-rails (~> 4.2)
   factory_bot_rails
   fast_jsonapi
+  figaro
   jbuilder (~> 2.5)
   launchy
   listen (>= 3.0.5, < 3.2)

--- a/app/controllers/api/v1/forecast_controller.rb
+++ b/app/controllers/api/v1/forecast_controller.rb
@@ -5,7 +5,7 @@ module Api
     # A controller to take in a forecast request, process it, and return JSON
     class ForecastController < ApplicationController
       def show
-        google_maps_service.geocodes(params[:location])
+        google_maps_service.geocode(params[:location])
         render json: ForecastSerializer.new
       end
 

--- a/app/controllers/api/v1/forecast_controller.rb
+++ b/app/controllers/api/v1/forecast_controller.rb
@@ -5,7 +5,14 @@ module Api
     # A controller to take in a forecast request, process it, and return JSON
     class ForecastController < ApplicationController
       def show
+        google_maps_service.geocodes(params[:location])
         render json: ForecastSerializer.new
+      end
+
+      private
+
+      def google_maps_service
+        @_google_maps_service = GoogleMapsService.new
       end
     end
   end

--- a/app/services/google_maps_service.rb
+++ b/app/services/google_maps_service.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# A Service to access the Google Maps API for geocoding
+class GoogleMapsService
+  def geocodes(address)
+    get_json("geocode/json", {address: address})
+  end
+
+  private
+
+  def get_json(url, params)
+    response = conn.get(url, default_params.merge(params))
+    JSON.parse(response.body, symbolize_names: true)
+  end
+
+  def conn
+    Faraday.new("https://maps.googleapis.com/maps/api")
+  end
+
+  def default_params
+    {
+      key: ENV['GOOGLE_MAPS_KEY']
+    }
+  end
+end

--- a/app/services/google_maps_service.rb
+++ b/app/services/google_maps_service.rb
@@ -2,7 +2,7 @@
 
 # A Service to access the Google Maps API for geocoding
 class GoogleMapsService
-  def geocodes(address)
+  def geocode(address)
     get_json("geocode/json", {address: address})
   end
 

--- a/app/services/google_maps_service.rb
+++ b/app/services/google_maps_service.rb
@@ -3,7 +3,7 @@
 # A Service to access the Google Maps API for geocoding
 class GoogleMapsService
   def geocode(address)
-    get_json("geocode/json", {address: address})
+    get_json('geocode/json', address: address)
   end
 
   private
@@ -14,7 +14,7 @@ class GoogleMapsService
   end
 
   def conn
-    Faraday.new("https://maps.googleapis.com/maps/api")
+    Faraday.new('https://maps.googleapis.com/maps/api')
   end
 
   def default_params

--- a/spec/services/google_maps_spec.rb
+++ b/spec/services/google_maps_spec.rb
@@ -3,14 +3,14 @@
 require 'rails_helper'
 
 RSpec.describe GoogleMapsService do
-  it '#geocodes' do
-      geocodes = subject.geocodes('denver, co')
+  it '#geocode' do
+      geocode = subject.geocode('denver, co')
 
-      expect(geocodes).to be_a Hash
-      expect(geocodes[:results]).to be_an Array
-      expect(geocodes[:results].first).to have_key :geometry
-      expect(geocodes[:results].first[:geometry]).to have_key :location
-      expect(geocodes[:results].first[:geometry][:location]).to have_key :lat
-      expect(geocodes[:results].first[:geometry][:location]).to have_key :lng
+      expect(geocode).to be_a Hash
+      expect(geocode[:results]).to be_an Array
+      expect(geocode[:results].first).to have_key :geometry
+      expect(geocode[:results].first[:geometry]).to have_key :location
+      expect(geocode[:results].first[:geometry][:location]).to have_key :lat
+      expect(geocode[:results].first[:geometry][:location]).to have_key :lng
     end
 end

--- a/spec/services/google_maps_spec.rb
+++ b/spec/services/google_maps_spec.rb
@@ -4,13 +4,13 @@ require 'rails_helper'
 
 RSpec.describe GoogleMapsService do
   it '#geocode' do
-      geocode = subject.geocode('denver, co')
+    geocode = subject.geocode('denver, co')
 
-      expect(geocode).to be_a Hash
-      expect(geocode[:results]).to be_an Array
-      expect(geocode[:results].first).to have_key :geometry
-      expect(geocode[:results].first[:geometry]).to have_key :location
-      expect(geocode[:results].first[:geometry][:location]).to have_key :lat
-      expect(geocode[:results].first[:geometry][:location]).to have_key :lng
-    end
+    expect(geocode).to be_a Hash
+    expect(geocode[:results]).to be_an Array
+    expect(geocode[:results].first).to have_key :geometry
+    expect(geocode[:results].first[:geometry]).to have_key :location
+    expect(geocode[:results].first[:geometry][:location]).to have_key :lat
+    expect(geocode[:results].first[:geometry][:location]).to have_key :lng
+  end
 end

--- a/spec/services/google_maps_spec.rb
+++ b/spec/services/google_maps_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe GoogleMapsService do
+  it '#geocodes' do
+      geocodes = subject.geocodes('denver, co')
+
+      expect(geocodes).to be_a Hash
+      expect(geocodes[:results]).to be_an Array
+      expect(geocodes[:results].first).to have_key :geometry
+      expect(geocodes[:results].first[:geometry]).to have_key :location
+      expect(geocodes[:results].first[:geometry][:location]).to have_key :lat
+      expect(geocodes[:results].first[:geometry][:location]).to have_key :lng
+    end
+end


### PR DESCRIPTION
This PR brings in the functionality of a GoogleMaps service, and access to the GoogleMaps Geocode endpoint. Since we will be using the GoogleMaps API for their Directions endpoint as well, this will keep the service reusable.
The service instantiates with no parameters, just setting up the API Key that is required for all requests.
The `geocode` method takes in the `city, state` param that we have received from our endpoint, and then reaches out to the Google Geocode endpoint, using that as the `address` param that they ask for.
For now, this information is just returned to the controller, but will be passed to the next step in the process, the Darksky Service.

resolves #3 