### PR TITLE
DarkSky Service

### DIFF
--- a/app/controllers/api/v1/forecast_controller.rb
+++ b/app/controllers/api/v1/forecast_controller.rb
@@ -5,14 +5,21 @@ module Api
     # A controller to take in a forecast request, process it, and return JSON
     class ForecastController < ApplicationController
       def show
-        google_maps_service.geocode(params[:location])
+        geocode = google_maps_service.geocode(params[:location])[:results][0]
+        lat = geocode[:geometry][:location][:lat]
+        long = geocode[:geometry][:location][:lng]
+        dark_sky_service.forecast([lat, long])
         render json: ForecastSerializer.new
       end
 
       private
 
       def google_maps_service
-        @_google_maps_service = GoogleMapsService.new
+        @_google_maps_service ||= GoogleMapsService.new
+      end
+
+      def dark_sky_service
+        @_dark_sky_service ||= DarkSkyService.new
       end
     end
   end

--- a/app/services/dark_sky_service.rb
+++ b/app/services/dark_sky_service.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# A service to reach out to the Dark Sky API and receive forecast information based on LatLong
+class DarkSkyService
+  def forecast(lat_long)
+    lat, long = lat_long
+    get_json("forecast/#{ENV['DARK_SKY_KEY']}/#{lat},#{long}")
+  end
+
+  private
+
+  def get_json(url, params = {})
+    response = conn.get(url, params)
+    JSON.parse(response.body, symbolize_names: true)
+  end
+
+  def conn
+    Faraday.new('https://api.darksky.net')
+  end
+end

--- a/spec/services/dark_sky_spec.rb
+++ b/spec/services/dark_sky_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DarkSkyService do
+  it 'forecast' do
+    forecast = subject.forecast([39.7392358, -104.990251])
+
+    expect(forecast).to be_a Hash
+    expect(forecast[:currently]).to be_a Hash
+    expect(forecast[:currently]).to have_key :summary
+    expect(forecast[:currently]).to have_key :icon
+    expect(forecast[:currently]).to have_key :precipProbability
+    # expect(forecast[:currently]).to have_key :precipType
+    expect(forecast[:currently]).to have_key :time
+    expect(forecast[:currently]).to have_key :temperature
+    expect(forecast[:currently]).to have_key :apparentTemperature
+    expect(forecast[:currently]).to have_key :humidity
+    expect(forecast[:currently]).to have_key :visibility
+    expect(forecast[:currently]).to have_key :ozone
+
+    expect(forecast[:hourly]).to be_a Hash
+    expect(forecast[:hourly]).to have_key :summary
+    expect(forecast[:hourly]).to have_key :icon
+    expect(forecast[:hourly]).to have_key :data
+
+    expect(forecast[:daily]).to be_a Hash
+    expect(forecast[:daily]).to have_key :summary
+    expect(forecast[:daily]).to have_key :icon
+    expect(forecast[:daily]).to have_key :data
+  end
+end


### PR DESCRIPTION
This PR implements the DarkSky API service to reach out to their Forecast endpoint using the coordinates that we get from the Google Geocode service we created earlier.
The Service is pretty simple for the time being, as we have not implemented a processor of the data yet. The spec should cover just about all the information we are going to need on our page to represent the current and future weather for our users.