### PR TITLE
User Creation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem 'jbuilder', '~> 2.5'
 # Use Redis adapter to run Action Cable in production
 # gem 'redis', '~> 4.0'
 # Use ActiveModel has_secure_password
-# gem 'bcrypt', '~> 3.1.7'
+gem 'bcrypt', '~> 3.1.7'
 
 # Use ActiveStorage variant
 # gem 'mini_magick', '~> 4.8'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,6 +45,7 @@ GEM
     addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
     arel (9.0.0)
+    bcrypt (3.1.13)
     bindex (0.8.1)
     bootsnap (1.4.4)
       msgpack (~> 1.0)
@@ -233,6 +234,7 @@ PLATFORMS
 
 DEPENDENCIES
   activesupport
+  bcrypt (~> 3.1.7)
   bootsnap (>= 1.1.0)
   byebug
   capybara

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -5,8 +5,22 @@ module Api
     # A controller to create users in our Database
     class UsersController < ApplicationController
       def create
-        user = User.create({ email: params[:email], password: params[:password], password_confirmation: params[:password_confirmation] })
-        render json: { 'test': 'test' }
+        user = User.new(user_params)
+        if user.save
+          render json: { api_key: user.api_key }
+        else
+          render json: { errors: user.errors.messages }
+        end
+      end
+
+      private
+
+      def user_params
+        {
+          email: params[:email],
+          password: params[:password],
+          password_confirmation: params[:password_confirmation]
+        }
       end
     end
   end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    # A controller to create users in our Database
+    class UsersController < ApplicationController
+      def create
+        user = User.create({ email: params[:email], password: params[:password], password_confirmation: params[:password_confirmation] })
+        render json: { 'test': 'test' }
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -7,9 +7,9 @@ module Api
       def create
         user = User.new(user_params)
         if user.save
-          render json: { api_key: user.api_key }
+          render json: { api_key: user.api_key }, status: 201
         else
-          render json: { errors: user.errors.messages }
+          render json: { errors: user.errors.messages }, status: 409
         end
       end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,3 +1,6 @@
+# frozen_string_literal: true
+
+# A model to store a user of the site, and attaching access to an API Key
 class User < ApplicationRecord
   validates :email, presence: true, uniqueness: true
   has_secure_password

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,4 @@
+class User < ApplicationRecord
+  validates :email, presence: true, uniqueness: true
+  has_secure_password
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,12 @@
 class User < ApplicationRecord
   validates :email, presence: true, uniqueness: true
   has_secure_password
+
+  before_create :set_api_key
+
+  private
+
+  def set_api_key
+    self.api_key = SecureRandom.urlsafe_base64.to_s
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,8 @@ Rails.application.routes.draw do
       get '/forecast', to: 'forecast#show'
 
       get '/background', to: 'background#show'
+
+      resources :users, only: [:create]
     end
   end
 end

--- a/db/migrate/20190731130434_create_users.rb
+++ b/db/migrate/20190731130434_create_users.rb
@@ -1,0 +1,10 @@
+class CreateUsers < ActiveRecord::Migration[5.2]
+  def change
+    create_table :users do |t|
+      t.string :email
+      t.string :password_digest
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20190731131859_add_api_key_to_users.rb
+++ b/db/migrate/20190731131859_add_api_key_to_users.rb
@@ -1,0 +1,5 @@
+class AddApiKeyToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :api_key, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_31_130434) do
+ActiveRecord::Schema.define(version: 2019_07_31_131859) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -20,6 +20,7 @@ ActiveRecord::Schema.define(version: 2019_07_31_130434) do
     t.string "password_digest"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "api_key"
   end
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,25 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# Note that this schema.rb definition is the authoritative source for your
+# database schema. If you need to create the application database on another
+# system, you should be using db:schema:load, not running all the migrations
+# from scratch. The latter is a flawed and unsustainable approach (the more migrations
+# you'll amass, the slower it'll run and the greater likelihood for issues).
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 2019_07_31_130434) do
+
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+  create_table "users", force: :cascade do |t|
+    t.string "email"
+    t.string "password_digest"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,6 +1,8 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :user do
-    email { "MyString" }
-    password_digest { "MyString" }
+    email { 'MyString' }
+    password_digest { 'MyString' }
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :user do
+    email { "MyString" }
+    password_digest { "MyString" }
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,13 @@
+#frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe User, type: :model do
+  context 'validations' do
+    it { should validate_presence_of :email }
+    it { should validate_uniqueness_of :email }
+
+    it { should have_secure_password }
+    it { should validate_presence_of :password }
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,4 +1,4 @@
-#frozen_string_literal: true
+# frozen_string_literal: true
 
 require 'rails_helper'
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -9,5 +9,12 @@ RSpec.describe User, type: :model do
 
     it { should have_secure_password }
     it { should validate_presence_of :password }
+
+    it 'api_key' do
+      user = User.new(email: 'api@key.com', password_digest: 'test')
+      expect(user.api_key).to eq(nil)
+      user.save!
+      expect(user.api_key).to_not eq(nil)
+    end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -72,3 +72,10 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
 end
+
+Shoulda::Matchers.configure do |config|
+  config.integrate do |with|
+    with.test_framework :rspec
+    with.library :rails
+  end
+end

--- a/spec/requests/users/create_spec.rb
+++ b/spec/requests/users/create_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'Users Create API' do
+  it 'can create a user' do
+    post api_v1_users_path, params: { 'email': 'test@test.com', 'password': 'password', 'password_confirmation': 'password'}
+
+    expect(response).to be_successful
+
+    result = JSON.parse(response.body, symbolize_names: true)
+
+    expect(result[:api_key]).to_not be nil
+  end
+end

--- a/spec/requests/users/create_spec.rb
+++ b/spec/requests/users/create_spec.rb
@@ -7,6 +7,7 @@ describe 'Users Create API' do
     post api_v1_users_path, params: { 'email': 'test@test.com', 'password': 'password', 'password_confirmation': 'password'}
 
     expect(response).to be_successful
+    expect(response.status).to eq(201)
 
     result = JSON.parse(response.body, symbolize_names: true)
 
@@ -17,7 +18,8 @@ describe 'Users Create API' do
     User.create!(email: 'test@test.com', password_digest: 'failure')
     post api_v1_users_path, params: { 'email': 'test@test.com', 'password': 'password', 'password_confirmation': 'password'}
 
-    expect(response).to be_successful
+    expect(response).to_not be_successful
+    expect(response.status).to eq(409)
 
     result = JSON.parse(response.body, symbolize_names: true)
 

--- a/spec/requests/users/create_spec.rb
+++ b/spec/requests/users/create_spec.rb
@@ -9,7 +9,7 @@ describe 'Users Create API' do
     expect(response).to be_successful
 
     result = JSON.parse(response.body, symbolize_names: true)
-
-    expect(result[:api_key]).to_not be nil
+    
+    expect(result[:api_key]).to_not eq(nil)
   end
 end

--- a/spec/requests/users/create_spec.rb
+++ b/spec/requests/users/create_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 describe 'Users Create API' do
   it 'can create a user' do
-    post api_v1_users_path, params: { 'email': 'test@test.com', 'password': 'password', 'password_confirmation': 'password'}
+    post api_v1_users_path, params: { 'email': 'test@test.com', 'password': 'password', 'password_confirmation': 'password' }
 
     expect(response).to be_successful
     expect(response.status).to eq(201)
@@ -16,7 +16,7 @@ describe 'Users Create API' do
 
   it 'can not create a user with an existing email' do
     User.create!(email: 'test@test.com', password_digest: 'failure')
-    post api_v1_users_path, params: { 'email': 'test@test.com', 'password': 'password', 'password_confirmation': 'password'}
+    post api_v1_users_path, params: { 'email': 'test@test.com', 'password': 'password', 'password_confirmation': 'password' }
 
     expect(response).to_not be_successful
     expect(response.status).to eq(409)

--- a/spec/requests/users/create_spec.rb
+++ b/spec/requests/users/create_spec.rb
@@ -9,7 +9,19 @@ describe 'Users Create API' do
     expect(response).to be_successful
 
     result = JSON.parse(response.body, symbolize_names: true)
-    
+
     expect(result[:api_key]).to_not eq(nil)
+  end
+
+  it 'can not create a user with an existing email' do
+    User.create!(email: 'test@test.com', password_digest: 'failure')
+    post api_v1_users_path, params: { 'email': 'test@test.com', 'password': 'password', 'password_confirmation': 'password'}
+
+    expect(response).to be_successful
+
+    result = JSON.parse(response.body, symbolize_names: true)
+
+    expect(result[:api_key]).to eq(nil)
+    expect(result[:errors][:email]).to eq(['has already been taken'])
   end
 end


### PR DESCRIPTION
This PR brings in the functionality of a User, and how they have an API key that will be used in later stories. Users are created via the `api/v1/users` endpoint, with a Post request. Users only have an Email and Password for their required information. Upon being saved into the database, an API Key attribute is added to their resource in the table.
The request endpoint will return the API key in the body of the response if the user does not already have their email associated with an account in our database. If they do have an account, they will receive a message stating the error message for duplicate emails from ActiveRecord.
We are using Bcrypt for secure password storage, and API Keys are a random URL Safe Base64 string.

resolves #9 