### PR TITLE
User Login

### DIFF
--- a/app/controllers/api/v1/sessions_controller.rb
+++ b/app/controllers/api/v1/sessions_controller.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    # A controller to create a session for a user, and return an API key
+    class SessionsController < ApplicationController
+      def create
+        user = User.find_by(email: params[:email])
+        if user && user.authenticate(params[:password])
+          render json: { api_key: user.api_key }
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/sessions_controller.rb
+++ b/app/controllers/api/v1/sessions_controller.rb
@@ -8,6 +8,8 @@ module Api
         user = User.find_by(email: params[:email])
         if user && user.authenticate(params[:password])
           render json: { api_key: user.api_key }
+        else
+          render json: { errors: { account: ['does not match'] } }, status: 401
         end
       end
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
       get '/background', to: 'background#show'
 
       resources :users, only: [:create]
+      post '/sessions', to: 'sessions#create'
     end
   end
 end

--- a/spec/requests/users/login_spec.rb
+++ b/spec/requests/users/login_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'Users Login API' do
+  it 'can create a session' do
+    User.create!(email: 'test@test.com', password: 'password')
+    post api_v1_sessions_path, params: { 'email': 'test@test.com', 'password': 'password' }
+
+    expect(response).to be_successful
+
+    result = JSON.parse(response.body, symbolize_names: true)
+
+    expect(result[:api_key]).to_not eq(nil)
+  end
+
+end

--- a/spec/requests/users/login_spec.rb
+++ b/spec/requests/users/login_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 describe 'Users Login API' do
   it 'can create a session' do
     User.create!(email: 'test@test.com', password: 'password')
-    post api_v1_sessions_path, params: { 'email': 'test@test.com', 'password': 'password' }
+    post api_v1_sessions_path, params: { email: 'test@test.com', password: 'password' }
 
     expect(response).to be_successful
 
@@ -14,4 +14,16 @@ describe 'Users Login API' do
     expect(result[:api_key]).to_not eq(nil)
   end
 
+  it 'can not create a session with an incorrect password' do
+    User.create!(email: 'test@test.com', password: 'password')
+    post api_v1_sessions_path, params: { email: 'test@test.com', password: 'failure' }
+
+    expect(response).to_not be_successful
+    expect(response.status).to eq(401)
+
+    result = JSON.parse(response.body, symbolize_names: true)
+
+    expect(result[:api_key]).to eq(nil)
+    expect(result[:errors][:account]).to eq(['does not match'])
+  end
 end


### PR DESCRIPTION
This PR brings in the functionality for an existing User to sign in and receive their API key for future access. This is done through a SessionsController and Sessions endpoint for our API.
When a User has already signed up with an email and password, they can send a POST request to our `sessions` endpoint with their correct information, and they will receive in response their API key.
If they do not provide the correct information, they will get a 401 Unauthorized response, and a message stating that their account information does not match.
This uses Bcrypts built in #authenticate options to ensure the password matches what we have stored in a digest. We find the user by their email, and then ensure they are who they say they are.