### PR TITLE
Request Caching: Forecasts and RoadTrips

### DIFF
--- a/app/generators/background_generator.rb
+++ b/app/generators/background_generator.rb
@@ -6,12 +6,17 @@ class BackgroundGenerator
 
   def initialize(location)
     @id = "#{location} background image"
-    unsplash_search = unsplash_service.search(location.split(',')[0])
-    unsplash_image = unsplash_search[:results][0]
+    unsplash_image = unsplash_search(location)[:results][0]
     @image = Background.new(unsplash_image)
   end
 
   private
+
+  def unsplash_search(location)
+    Rails.cache.fetch("background-#{location}", expires_in: 24.hours) do
+      unsplash_service.search(location.split(',')[0])
+    end
+  end
 
   def unsplash_service
     @_unsplash_service ||= UnsplashService.new


### PR DESCRIPTION
This PR brings in caching to reduce extraneous calls to external API's, like Google, Darksky, and Unsplash. Since these calls happen every time somebody hits one of our endpoints, and some of the information does not change drastically over time, it makes sense to cache that information locally.
- Forecasts cache updates every 30 minutes
- Geocode and Directions cache updates every 24 hours, as Google does not take traffic into account
- Background Images cache updates every 24 hours